### PR TITLE
2: Setup test env

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --progress --profile --colors"
+    "start": "webpack-dev-server --progress --profile --colors",
+    "test": "./node_modules/.bin/intern-runner config=tests/intern"
   },
   "repository": {
     "type": "git",
@@ -21,6 +22,7 @@
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.16.0",
     "css-loader": "^0.25.0",
+    "intern": "^3.3.1",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "style-loader": "^0.13.1",

--- a/tests/functional/index.js
+++ b/tests/functional/index.js
@@ -1,0 +1,17 @@
+define(function (require) {
+    var registerSuite = require("intern!object");
+    var assert = require("intern/chai!assert");
+
+    registerSuite({
+        name: "Basic Tests",
+
+        "Page is loaded": function () {
+            return this.remote.get(require.toUrl("http://localhost:8080/index.html"))
+               .findByCssSelector("div")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "Hello World");
+                  });
+        }
+    });
+});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -1,0 +1,23 @@
+define({
+   capabilities: {
+      "browserstack.selenium_version": "2.45.0"
+   },
+
+   environments: [
+      { browserName: "chrome" }
+   ],
+
+   maxConcurrency: 1,
+
+   tunnel: "NullTunnel",
+
+   loaderOptions: {
+      
+   },
+
+   suites: [],
+
+   functionalSuites: [ "tests/functional/index" ],
+
+   excludeInstrumentation: /^(?:tests|node_modules)\//
+});


### PR DESCRIPTION
This PR addresses #2 to setup Intern as a unit testing framework. I've added a single test just to verify that the application page is loading. This does rely on selenium standalone being installed for testing - I'll need to update the release notes.
