### PR TITLE
3: Added a module for the API key and tested import

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -1,1 +1,16 @@
 require("./styles.less");
+
+// Import the API key module...
+import apiKey from "./modules/apiKey";
+
+// Simple test that the key has been configured, this will be improved...
+var d = document.createElement("div");
+if (apiKey.key)
+{
+   d.appendChild(document.createTextNode("API Key is: " + apiKey));
+}
+else
+{
+   d.appendChild(document.createTextNode("No API Key Configured"));
+}
+document.getElementById("BODY").appendChild(d);

--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>
-    <body>
-        <div>Hello World</div>
+    <body id="BODY">
         <script type="text/javascript" src="bundle.js" charset="utf-8"></script>
     </body>
 </html>

--- a/modules/apiKey.js
+++ b/modules/apiKey.js
@@ -1,0 +1,10 @@
+// In order to be able to make requests to the Movie DB it is necessary to 
+// change the assignment of the MY_API_KEY const below to your own API key
+// To get an API key you need to register with the Movie DB (at https://www.themoviedb.org) 
+// and request an API key from your account page.
+
+const MY_API_KEY = null;
+
+export default {
+   key: MY_API_KEY
+};

--- a/tests/functional/index.js
+++ b/tests/functional/index.js
@@ -1,17 +1,17 @@
 define(function (require) {
-    var registerSuite = require("intern!object");
-    var assert = require("intern/chai!assert");
+   var registerSuite = require("intern!object");
+   var assert = require("intern/chai!assert");
 
-    registerSuite({
-        name: "Basic Tests",
+   registerSuite({
+      name: "Basic Tests",
 
-        "Page is loaded": function () {
-            return this.remote.get(require.toUrl("http://localhost:8080/index.html"))
-               .findByCssSelector("div")
-                  .getVisibleText()
-                  .then(function(text) {
-                     assert.equal(text, "Hello World");
-                  });
+      "No API Key Message": function () {
+         return this.remote.get(require.toUrl("http://localhost:8080/index.html"))
+            .findByCssSelector("div")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "No API Key Configured");
+               });
         }
     });
 });


### PR DESCRIPTION
This PR addresses issue #3 to define a new module to hold the API key. I don't want to expose my own key on a public GitHub repository. It's assumed users of the application will either have their own key or can request one. 
